### PR TITLE
Changed staging to connect to staging backend AWS

### DIFF
--- a/src/qdt-env.js
+++ b/src/qdt-env.js
@@ -1,4 +1,4 @@
-let api_url = "https://test.platform.forus.io/api/v1";
+let api_url = "https://demo.api.forus.link/api/v1";
 
 module.exports = {
     // browsersync configs


### PR DESCRIPTION
staging branch is connected to the frontend that are deployed to demo.forus.io

this change will make the frontends connect to staging aws backend located on demo.api.forus.link