### PR TITLE
Prevent QR code from rendering twice when opening modal again.

### DIFF
--- a/src/sources/forus-webshop/js/angular-1/directives/PopupAuthDirective.js
+++ b/src/sources/forus-webshop/js/angular-1/directives/PopupAuthDirective.js
@@ -146,9 +146,11 @@ let PopupAuthDirective = function(
 
     let $ctrl = this;
     let qrCodeEl;
+    let qrCode;
 
     this.$onInit = function() {
         qrCodeEl = document.getElementById('auth_qrcode');
+        qrCode = new QRCode(qrCodeEl);
     }
 
     if (AuthService.hasCredentials()) {
@@ -186,12 +188,12 @@ let PopupAuthDirective = function(
         IdentityService.makeAuthToken().then((res) => {
             $ctrl.authToken = res.data.auth_token;
 
-            new QRCode(qrCodeEl, {
-                text: JSON.stringify({
+            qrCode.makeCode(
+                JSON.stringify({
                     type: 'auth_token',
                     'value': $ctrl.authToken
                 })
-            });
+            );
 
             qrCodeEl.removeAttribute('title');
 


### PR DESCRIPTION
Fixes this:

<img width="564" alt="screen shot 2018-09-27 at 10 17 35 am" src="https://user-images.githubusercontent.com/7931323/46132554-9d712900-c23e-11e8-869f-85f8ab14a583.png">
