### PR TITLE
Fix adding new fund categories, form error css, webshop footer css

### DIFF
--- a/src/sources/forus-platform/js/angular-1/routers/router.js
+++ b/src/sources/forus-platform/js/angular-1/routers/router.js
@@ -342,7 +342,7 @@ module.exports = ['$stateProvider', '$locationProvider', 'appConfigs', function(
                 return FundService.states();
             },
             productCategories: function(permission, ProductCategoryService) {
-                return repackResponse(ProductCategoryService.list());
+                return repackResponse(ProductCategoryService.listAll());
             }
         }
     });

--- a/src/sources/forus-platform/scss/_common/dashboard.scss
+++ b/src/sources/forus-platform/scss/_common/dashboard.scss
@@ -199,6 +199,8 @@ translate,
         font: 400 13px/24px $bf;
         color: $bec;
         margin: 0;
+
+        &:first-letter {text-transform:uppercase}
     }
 
     .form-label {
@@ -3208,6 +3210,8 @@ translate,
     font: 400 13px/24px $bf;
     color: $bec;
     margin: 0;
+
+    &:first-letter {text-transform:uppercase}
 }
 
 

--- a/src/sources/forus-webshop/scss/_common/webshop.scss
+++ b/src/sources/forus-webshop/scss/_common/webshop.scss
@@ -41,9 +41,17 @@ body {
     background-color: #f3f8fe;
     background: linear-gradient(to bottom, #f3f8fe 0%,#feffff 100%);
 
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+
     &.modal-shown {
         overflow: hidden;
     }
+}
+
+ui-view{
+    flex: 1;
 }
 
 .triangle {


### PR DESCRIPTION
Fund update: when adding new fund you can only select categories of existing fund. #508
Landing: Footer should stick to the bottom of the page. #421
Set first letter of error message to uppercase #494