### PR TITLE
fix 'fund-request' auth success screen missing 'email' and 'br' tags,…

### DIFF
--- a/src/sources/forus-platform/js/angular-1/directives/landing/AuthDirective.js
+++ b/src/sources/forus-platform/js/angular-1/directives/landing/AuthDirective.js
@@ -13,26 +13,18 @@ let AuthDirective = function(
     let timeout;
 
     $scope.qrValue = null;
+    $scope.emailSent = false;
 
     $scope.form = FormBuilderService.build({
         email: "",
     }, function(form) {
-        form.lock();
-        IdentityService.makeAuthEmailToken(form.values.email).then((res) => {
-            ModalService.open('modalNotification', {
-                type: 'action-result',
-                class: 'modal-description-pad modal-content',
-                email: form.values.email,
-                icon: 'icon-sign_up-success',
-                title: 'popup_auth.labels.mail_sent',
-                description: 'popup_auth.notifications.link',
-                confirmBtnText: 'popup_auth.buttons.confirm',
+        IdentityService.makeAuthEmailToken(form.values.email).then(
+            () => $scope.emailSent = true,
+            (res) => {
+                form.unlock();
+                form.errors = res.data.errors ? res.data.errors : { email: [res.data.message] };
             });
-        }, (res) => {
-            form.unlock();
-            form.errors = res.data.errors ? res.data.errors : { email: [res.data.message] };
-        });
-    });
+    }, true);
 
     $scope.checkAccessTokenStatus = (type, access_token) => {
         IdentityService.checkAccessToken(access_token).then((res) => {

--- a/src/sources/forus-platform/js/angular-1/i18n/i18n-nl.js
+++ b/src/sources/forus-platform/js/angular-1/i18n/i18n-nl.js
@@ -1527,7 +1527,7 @@ module.exports = {
         },
         notifications: {
             confirmation: "Het is gelukt!",
-            link: "Er is een e-mail verstuurd naar <b>{{email}}</b>. Klik op de link om u aan te melden.",
+            link: "Er is een e-mail verstuurd naar <strong class=\"text-primary\">{{email}}</strong>.<br/>Klik op de link om u aan te melden.",
             link_website: "Er is een e-mail naar uw inbox gestuurd. In de e-mail vindt u een link waarmee u kunt inloggen op deze website.",
             invalid: "De activatiecode is ongeldig of al gebruikt",
             voucher_email: "Het is gelukt, de e-mail is verstuurd",

--- a/src/sources/forus-platform/pug/tpl/directives/landing/auth.pug
+++ b/src/sources/forus-platform/pug/tpl/directives/landing/auth.pug
@@ -1,7 +1,8 @@
 - var src_prefix = (qdt_c.platform.env_data.html5ModeEnabled?qdt_c.platform.env_data.html5Mode.basePath:'');
 
 .block.block-login: .block-login-window
-    .block-login-content
+    //- Auth form
+    .block-login-content(ng-if="!emailSent")
         .block-login-title Login met e-mail
         .block-login-description Vul uw e-mailadres in om een link te ontvangen waarmee u kunt inloggen
         
@@ -39,7 +40,15 @@
                     ng-if="qrValue" 
                     qr-value="qrValue" 
                     qr-type="auth_token" qr-logo=src_prefix + "./assets/img/me-logo.png")
-                
-    .block-login-footer
+
+    //- Footer
+    .block-login-footer(ng-if="!emailSent")
         .block-login-footer-title Nog geen account?
         a(ui-sref="sign-up").block-login-footer-button Inschrijven
+    
+    //- Email sent message
+    .block-login-content(ng-if="emailSent")
+        .block-login-email_sent
+            .block-login-email_sent-icon: img(src=src_prefix + "./assets/img/sign_up-email.svg").sign_up-email_sent-icon-img
+            .block-login-email_sent-title(translate="popup_auth.labels.join")
+            .block-login-email_sent-text(translate="popup_auth.notifications.link" translate-values="{{ form.values }}")

--- a/src/sources/forus-platform/scss/_common/dashboard.scss
+++ b/src/sources/forus-platform/scss/_common/dashboard.scss
@@ -5425,6 +5425,7 @@ $colorPrimaryLight: $color_primary_light;
         @include fill_parent();
         position: fixed;
         padding-bottom: 60px;
+        cursor: default;
 
         .block-login-window {
             display: block;
@@ -5545,6 +5546,37 @@ $colorPrimaryLight: $color_primary_light;
                         }
                     }
                 }
+            }
+
+            .block-login-email_sent {
+                text-align: center;
+
+                .block-login-email_sent-icon {
+                    margin: 0 auto 10px;
+
+                    .block-login-email_sent-icon-img {
+                        display: block;
+                        width: 300px;
+                        max-width: 100%;
+                        margin: auto;
+                    }
+                }
+
+                .block-login-email_sent-title {
+                    font: 500 28px/38px $bf;
+                    color: $color_primary;
+                    margin: 0 0 20px;
+                }
+
+                .block-login-email_sent-text {
+                    font: 500 18px/27px $bf;
+                    color: #454545;
+                    margin: 0 0 20px;
+                }
+            }
+
+            &:last-child {
+                border-bottom: none;
             }
         }
     

--- a/src/sources/forus-webshop/js/angular-1/i18n/nl/modals/modal-auth.js
+++ b/src/sources/forus-webshop/js/angular-1/i18n/nl/modals/modal-auth.js
@@ -40,7 +40,7 @@ module.exports = {
     },
     notifications: {
         confirmation: "Het is gelukt!",
-        link: "Er is een e-mail verstuurd naar <b>{{email}}</b>. Klik op de link om u aan te melden.",
+        link: "Er is een e-mail verstuurd naar <strong class=\"text-primary\">{{email}}</strong>.<br/>Klik op de link om u aan te melden.",
         invalid: "De activatiecode is ongeldig of al gebruikt.",
         voucher_email: "Uw tegoed is verstuurd naar uw mail.",
     },

--- a/src/sources/forus-webshop/pug/tpl/pages/sign-up.pug
+++ b/src/sources/forus-webshop/pug/tpl/pages/sign-up.pug
@@ -103,8 +103,8 @@ header.section.section-sign-up-choose
                     .sign_up-email_sent
                         .sign_up-email_sent-icon
                             img(src=src_prefix + "./assets/img/sign_up-email.svg").sign_up-email_sent-icon-img
-                        .sign_up-email_sent-title(i18n="popup_auth.labels.join")
-                        .sign_up-email_sent-text(i18n="popup_auth.notifications.link")
+                        .sign_up-email_sent-title(translate="popup_auth.labels.join")
+                        .sign_up-email_sent-text(translate="popup_auth.notifications.link" translate-values="{{ $ctrl.authForm.values }}")
             
             //- For existing users
             .sign_up-pane(ng-if="$ctrl.authEmailSent")


### PR DESCRIPTION
… replace provider success sign-in modal with success screen