### PR TITLE
added resetter to images in footer markdown

### DIFF
--- a/src/sources/forus-webshop/scss/_common/layout/_footer.scss
+++ b/src/sources/forus-webshop/scss/_common/layout/_footer.scss
@@ -157,6 +157,11 @@
         .block.block-markdown h3 {
             margin: 0.9em 0 0.9em 0;
         }
+        
+        .block.block-markdown img {
+            width: auto !important;
+            height: auto !important;
+        }
 
         .footer-nav {
             .footer-nav-item {


### PR DESCRIPTION
fix for westerkwartier footer. important are needed as there are aswell importants in the block-markdown class to set the image to 100% width.