### PR TITLE
Minor remove incorrect naming for sorting

### DIFF
--- a/src/sources/forus-webshop/js/angular-1/components/ProvidersComponent.js
+++ b/src/sources/forus-webshop/js/angular-1/components/ProvidersComponent.js
@@ -7,13 +7,13 @@ const ProvidersComponent = function(
     const $ctrl = this;
 
     $ctrl.sortByOptions = [{
-        label: 'Naam aflopend (oplopend)',
+        label: 'Naam (oplopend)',
         value: {
             order_by: 'name',
             order_by_dir: 'asc',
         }
     }, {
-        label: 'Naam aflopend (aflopend)',
+        label: 'Naam (aflopend)',
         value: {
             order_by: 'name',
             order_by_dir: 'desc',


### PR DESCRIPTION
Same as on products
<img width="308" alt="Screenshot 2022-11-16 at 8 34 34 PM" src="https://user-images.githubusercontent.com/8695780/202264389-76a539d6-82f6-41c6-9962-5b5d551807e5.png">
