### PR TITLE
add only and except flags to builder

### DIFF
--- a/src/platforms/Webshops/WebshopWadenheuvelPlatform.js
+++ b/src/platforms/Webshops/WebshopWadenheuvelPlatform.js
@@ -23,6 +23,6 @@ platform.editTask('scss', (task) => {
 });
 
 // change server port
-platform.serve(5630, '/');
+platform.serve(5700, '/');
 
 module.exports = platform;

--- a/src/qdt/Library.js
+++ b/src/qdt/Library.js
@@ -33,16 +33,21 @@ const isInit = () => {
 if (fs.existsSync(envFile)) {
     // environment
     var qdt_e = require(envFile);
+    var core = qdt_e(require('./Core'));
+
+    if (typeof params?.only == 'string') {
+        core.enableOnly(params?.only.split(','));
+    }
+
+    if (typeof params?.except == 'string') {
+        core.disableOnly(params?.except.split(','));
+    }
 
     // configurations
-    var qdt_c = qdt_core.compileConfig({
-        platforms: qdt_e(require('./Core')).getConfig()
-    });
-
-    // group platform by source
+    var qdt_c = qdt_core.compileConfig({ platforms: core.getConfig()});
     var grouped_platforms = qdt_core.groupPlatforms(qdt_c.platforms);
 
-    // browser syncronization
+    // browser synchronization
     var browserSync = {};
     var browserSyncReload = {};
 


### PR DESCRIPTION
## Changes description
Added 2 new flags to the builder

  ### Example: only=frontend1,frontend2
  _Build only the sponsor and validator dashboards:_
  ```
  gulp build --only=dashboard_general_validator,dashboard_general_sponsor
  gulp scss --only=dashboard_general_validator,dashboard_general_sponsor
  gulp pug --only=dashboard_general_validator,dashboard_general_sponsor
  gulp js --only=dashboard_general_validator,dashboard_general_sponsor
  gulp --only=dashboard_general_validator,dashboard_general_sponsor
  ```
  ### Example: except=frontend1,frontend2
  _Build all but the sponsor and validator dashboards:_
  ```
  gulp build --except=dashboard_general_validator,dashboard_general_sponsor
  gulp scss --except=dashboard_general_validator,dashboard_general_sponsor
  gulp pug --except=dashboard_general_validator,dashboard_general_sponsor
  gulp js --except=dashboard_general_validator,dashboard_general_sponsor
  gulp --except=dashboard_general_validator,dashboard_general_sponsor
  ```

Also changed the default port for Wadenheuvel from 5630 to 5700  it was already used by Vergoedingen