### PR TITLE
fix error in console from phone-control and fix paste into pincode-co…

### DIFF
--- a/src/sources/forus-platform/js/angular-1/directives/PincodeControlDirective.js
+++ b/src/sources/forus-platform/js/angular-1/directives/PincodeControlDirective.js
@@ -129,8 +129,9 @@ const PincodeControl2Directive = function (
         e.stopPropagation();
         e.preventDefault();
 
+        const clipboardData = e?.clipboardData || e?.originalEvent?.clipboardData;
         const index = $dir.chars.indexOf(char);
-        const text = $dir.clearString(e?.clipboardData?.getData('text') || '', $dir.blockInputType);
+        const text = $dir.clearString(clipboardData?.getData('text') || '', $dir.blockInputType);
 
         $dir.updateModel(index, text)
     }

--- a/src/sources/forus-platform/js/angular-1/directives/phone_control/PhoneControlDirective.js
+++ b/src/sources/forus-platform/js/angular-1/directives/phone_control/PhoneControlDirective.js
@@ -22,7 +22,7 @@ const PhoneControlDirective = function (
     };
 
     $dir.clear = (value) => {
-        return value.replace(regEx, '').replace(regExSpace, '')
+        return value?.replace(regEx, '').replace(regExSpace, '') || '';
     }
 
     $dir.getFullPhoneNumber = () => {

--- a/src/sources/forus-webshop/js/angular-1/directives/PincodeControlDirective.js
+++ b/src/sources/forus-webshop/js/angular-1/directives/PincodeControlDirective.js
@@ -129,8 +129,9 @@ const PincodeControl2Directive = function (
         e.stopPropagation();
         e.preventDefault();
 
+        const clipboardData = e?.clipboardData || e?.originalEvent?.clipboardData;
         const index = $dir.chars.indexOf(char);
-        const text = $dir.clearString(e?.clipboardData?.getData('text') || '', $dir.blockInputType);
+        const text = $dir.clearString(clipboardData?.getData('text') || '', $dir.blockInputType);
 
         $dir.updateModel(index, text)
     }

--- a/src/sources/forus-webshop/js/angular-1/directives/phone_control/PhoneControlDirective.js
+++ b/src/sources/forus-webshop/js/angular-1/directives/phone_control/PhoneControlDirective.js
@@ -22,7 +22,7 @@ const PhoneControlDirective = function (
     };
 
     $dir.clear = (value) => {
-        return value.replace(regEx, '').replace(regExSpace, '')
+        return value?.replace(regEx, '').replace(regExSpace, '') || '';
     }
 
     $dir.getFullPhoneNumber = () => {


### PR DESCRIPTION
…ntrol on dashboard in some cases

## Changes description
- Fixed error in browser console when pressing any "non value" keys while phone control is still empty (ex: arrow down or shift) this error did not affect the control functionality
- Fixed paste into pincode-control functionality on dashboards in some cases.

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## Developer suggestions
Checkmark if PR:
- [ ] *Needs Translations*
- [ ] *Could affect implementations custom css*
- [ ] *Need mobile design help/work*
- [ ] *Design include inconsistent*

## QA checklist
- [ ] Tag @ sashoa if design review needed
- [ ] *No regress in implementations custom css* - changes are not breaking other implementations designes
- [ ] Feature is tested in different screen sizes - desktop, mobile
- [ ] WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- [ ] Translations are done
