### PR TITLE
Add flag to hide fund meta on fund detail page on webshop

### DIFF
--- a/src/qdt-env.sample.js
+++ b/src/qdt-env.sample.js
@@ -231,6 +231,9 @@ module.exports = (core) => {
 
                 // voucher settings
                 shareProducts: false,
+
+                // fund page setting
+                hideFundMeta: true,
             },
             sessions: sessions,
             google_maps_api_key: google_maps_api_key,

--- a/src/sources/forus-webshop/pug/tpl/pages/fund.pug
+++ b/src/sources/forus-webshop/pug/tpl/pages/fund.pug
@@ -53,7 +53,7 @@ main(id="main-content")
                 .fund-card: .fund-details
                     h1.fund-name(ng-bind="$ctrl.fund.name") 
                     .fund-description: .block.block-markdown: p(ng-if="$ctrl.fund.description_short" ng-bind="$ctrl.fund.description_short")
-                    .fund-details-items                                 
+                    .fund-details-items(ng-if="!$root.appConfigs.flags.hideFundMeta")
                         .fund-details-item
                             .fund-details-item-label Uitgifte door:
                             .fund-details-item-value(ng-bind="$ctrl.fund.organization.name")


### PR DESCRIPTION
## Changes description
Added new flag to qdt-env hideFundMeta (exists in qdt-env.sample.js)

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## Developer suggestions
Checkmark if PR:
- [ ] *Needs Translations*
- [ ] *Could affect implementations custom css*
- [ ] *Need mobile design help/work*
- [ ] *Design include inconsistent*

## QA checklist
- [ ] Tag @ sashoa if design review needed
- [ ] *No regress in implementations custom css* - changes are not breaking other implementations designes
- [ ] Feature is tested in different screen sizes - desktop, mobile
- [ ] WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- [ ] Translations are done
