### PR TITLE
Added alt text for search icon

### DIFF
--- a/src/sources/forus-webshop/pug/tpl/directives/top-navbar.pug
+++ b/src/sources/forus-webshop/pug/tpl/directives/top-navbar.pug
@@ -196,7 +196,8 @@ nav.block.block-navbar#navigation-menu(ng-class='{"scrolled" : $dir.hideOnScroll
             ng-if="$root.appConfigs.flags.genericSearchUseToggle && $root.appConfigs.flags.genericSearch" 
             ng-click="$dir.toggleSearchBox($event)"
             ng-class="{active: $root.showSearchBox}" 
-            role="button").subnav-search-button.hide-sm
+            role="button"
+            aria-label="Zoeken").subnav-search-button.hide-sm
             em.mdi.mdi-magnify
 
     mixin navbar_list()


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue description
       - there are advices from development side for QA or other stakeholders
-->
Added alt text for search icon
![image](https://github.com/teamforus/forus-frontend/assets/8695780/6714ef92-d4f7-429c-bc08-2b5e19f0801c)

To fix next issue from browser Lighthouse report
<img width="780" alt="Screenshot 2023-11-01 at 21 57 13" src="https://github.com/teamforus/forus-frontend/assets/8695780/33752c6f-d706-40e9-bec3-8f358cce0d91">

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## Developer suggestions
Checkmark if PR:
- [ ] *Needs Translations*
- [ ] *Could affect implementations custom css*
- [ ] *Need mobile design help/work*
- [ ] *Design include inconsistent*

## QA checklist
- [ ] Tag @ sashoa if design review needed
- [ ] *No regress in implementations custom css* - changes are not breaking other implementations designes
- [ ] Feature is tested in different screen sizes - desktop, mobile
- [ ] WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- [ ] Translations are done
