### PR TITLE
remove some identity product notifications

### DIFF
--- a/src/sources/forus-platform/js/angular-1/i18n/nl/pages/system-notifications.pug.i18n.js
+++ b/src/sources/forus-platform/js/angular-1/i18n/nl/pages/system-notifications.pug.i18n.js
@@ -68,18 +68,6 @@ module.exports = {
             "title": "Aanbieder goedgekeurd voor aanbiedingen",
             "description": "Deelnemers ontvangen dit bericht wanneer het aanbod van een aanbieder is goedgekeurd voor een fonds."
         },
-        "notifications_identities.requester_product_revoked": {
-            "title": "Aanbieder geweigerd voor aanbiedingen",
-            "description": "Deelnemers ontvangen dit bericht wanneer het aanbod van een aanbieder wordt verwijderd uit een fonds."
-        },
-        "notifications_identities.requester_product_approved": {
-            "title": "Aanbieder goedgekeurd voor een specifieke aanbieding",
-            "description": "Deelnemers ontvangen dit bericht wanneer een aanbieding van een aanbieder is goedgekeurd voor een fonds."
-        },
-        "notifications_identities.requester_product_added": {
-            "title": "Aanbieding toegevoegd aan de webshop",
-            "description": "Deelnemers ontvangen dit bericht wanneer een aanbieding van een aanbieder wordt toegevoegd aan een fonds."
-        },
         "notifications_identities.requester_fund_ended": {
             "title": "Fonds is afgelopen",
             "description": "Deelnemers ontvangen dit bericht wanneer een fonds van hun tegoed is afgelopen."


### PR DESCRIPTION
## Changes description
The following database notifications have been removed:
```
notifications_identities.requester_product_added
notifications_identities.requester_product_approved
notifications_identities.requester_product_revoked
```

## Developers checklist
- [x] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## Developer suggestions
Checkmark if PR:
- [ ] *Needs Translations*
- [ ] *Could affect implementations custom css*
- [ ] *Need mobile design help/work*
- [ ] *Design include inconsistent*

## QA checklist
- [ ] Tag @ sashoa if design review needed
- [ ] *No regress in implementations custom css* - changes are not breaking other implementations designes
- [ ] Feature is tested in different screen sizes - desktop, mobile
- [ ] WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- [ ] Translations are done
