### PR TITLE
fix missing translate lib on backend

### DIFF
--- a/src/sources/forus-platform/js/angular-1/services/Identity2FAService.js
+++ b/src/sources/forus-platform/js/angular-1/services/Identity2FAService.js
@@ -1,9 +1,12 @@
 const Identity2FAService = function (
     $q,
-    $filter,
     ApiRequest,
 ) {
-    const phoneError = $filter('translate')('modal_2fa_setup.errors.code_sent');
+    const phoneError = [
+        'Er is iets fout gegaan tijdens het versturen van de SMS.', 
+        'Is het juiste telefoonnummer ingevuld? Probeer het anders nog een keer.',
+    ].join(' ');
+
     const phoneErrorObj = { data: { message: phoneError, errors: { phone: [phoneError] } } };
 
     return new (function () {
@@ -48,7 +51,6 @@ const Identity2FAService = function (
 
 module.exports = [
     '$q',
-    '$filter',
     'ApiRequest',
     Identity2FAService,
 ];


### PR DESCRIPTION
## Changes description
The backend platform is missing a translation library, resulting in a missing dependency error on the login screen for me-app.

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## Developer suggestions
Checkmark if PR:
- [ ] *Needs Translations*
- [ ] *Could affect implementations custom css*
- [ ] *Need mobile design help/work*
- [ ] *Design include inconsistent*

## QA checklist
- [ ] Tag @ sashoa if design review needed
- [ ] *No regress in implementations custom css* - changes are not breaking other implementations designes
- [ ] Feature is tested in different screen sizes - desktop, mobile
- [ ] WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- [ ] Translations are done
